### PR TITLE
order GET now displays products nested within orders

### DIFF
--- a/BangazonAPI/Models/Order.cs
+++ b/BangazonAPI/Models/Order.cs
@@ -11,5 +11,7 @@ namespace BangazonAPI.Models
         public int CustomerId { get; set; }
 
         public int PaymentTypeId { get; set; }
+
+        public List<Product> Products { get; set; } = new List<Product>();
     }
 }


### PR DESCRIPTION
Changes proposed in this request & reasons behind organizational or architectural decisions:
- GET orders now retrieves order data with nested product data

Steps to test:
- STEP 1) Run the SQL from this file in Azure Data Studio
- STEP 2) Run the BangazonAPI in Visual Studio.
- STEP 3) With the program running, go to Postman and GET from http://localhost:5000/order
- Returned order objects should have nested product objects

Commit message:
- order GET now displays products nested within orders

Link to feature ticket:
- [#10](https://github.com/nss-day-cohort-30/bangazon-api-ambitious-albatrosses/issues/10)

@ambitious-albatrosses
